### PR TITLE
Use stderr for output from subprocess

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -168,7 +168,7 @@ def process(path, fromfile, tofile, processor_function, hash_db):
     fulltopath = os.path.join(path, tofile)
     current_hash = get_hash(fullfrompath, fulltopath)
     if current_hash == hash_db.get(normpath(fullfrompath), None):
-        sys.stderr.write('%s has not changed' % fullfrompath)
+        print('%s has not changed' % fullfrompath, file=sys.stderr)
         return
 
     orig_cwd = os.getcwd()

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -168,13 +168,13 @@ def process(path, fromfile, tofile, processor_function, hash_db):
     fulltopath = os.path.join(path, tofile)
     current_hash = get_hash(fullfrompath, fulltopath)
     if current_hash == hash_db.get(normpath(fullfrompath), None):
-        print('%s has not changed' % fullfrompath)
+        sys.stderr.write('%s has not changed' % fullfrompath)
         return
 
     orig_cwd = os.getcwd()
     try:
         os.chdir(path)
-        print('Processing %s' % fullfrompath)
+        sys.stderr.write('Processing %s' % fullfrompath)
         processor_function(fromfile, tofile)
     finally:
         os.chdir(orig_cwd)


### PR DESCRIPTION
contextlib.redirect_stdout does not support stdout of subprocesses

This is used by Fedora packaging RPM macros extensively.
Having subprovesses print to stdout, would otherwise require
manual patching of the script in the build process.
