### PR TITLE
Pin devpy to v0.1 and update to new API

### DIFF
--- a/.devpy/cmds.py
+++ b/.devpy/cmds.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 from devpy import util
+from devpy.cmds import meson
 
 @click.command()
 @click.option(
@@ -27,7 +28,7 @@ def docs(build_dir, clean=False):
             print(f"Removing `{doc_dir}`")
             shutil.rmtree(doc_dir)
 
-    site_path = util.get_site_packages(build_dir)
+    site_path = meson._get_site_packages()
     if site_path is None:
         print("No built scikit-misc found; run `./dev.py build` first.")
         sys.exit(1)
@@ -50,7 +51,7 @@ def coverage(build_dir):
     """
     📊 Generate coverage report
     """
-    site_path = util.get_site_packages(build_dir)
+    site_path = meson._get_site_packages()
     util.run([
         "python",
         "-m",
@@ -71,7 +72,7 @@ def coverage_html(build_dir):
     """
     📊 Generate HTML coverage report
     """
-    site_path = util.get_site_packages(build_dir)
+    site_path = meson._get_site_packages()
     util.run([
         "python",
         "-m",

--- a/dev.py
+++ b/dev.py
@@ -14,6 +14,6 @@ try:
 except ImportError:
     print("Cannot import devpy; please install it using")
     print()
-    print("  pip install git+https://github.com/scientific-python/devpy")
+    print("  pip install git+https://github.com/scientific-python/devpy@v0.1")
     print()
     sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,17 +80,17 @@ package = "skmisc"
 
 [tool.devpy.commands]
 Build = [
-    "devpy.build",
-    "devpy.test",
+    "devpy.cmds.meson.build",
+    "devpy.cmds.meson.test",
     ".devpy/cmds.py:docs",
     ".devpy/cmds.py:coverage",
     ".devpy/cmds.py:coverage_html",
     ".devpy/cmds.py:sdist",
 ]
 Environments = [
-    "devpy.shell",
-    "devpy.ipython",
-    "devpy.python",
+    "devpy.cmds.meson.shell",
+    "devpy.cmds.meson.ipython",
+    "devpy.cmds.meson.python",
 ]
 
 [tool.cibuildwheel]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,6 +1,6 @@
 Cython
 build
-git+https://github.com/scientific-python/devpy
+git+https://github.com/scientific-python/devpy@v0.1
 meson-python
 ninja
 numpy


### PR DESCRIPTION
Please note that `devpy` will soon be released as `spin`, due to pypi availability.