### PR TITLE
Allow building with Python >= 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ requires = [
     # default numpy requirements
     "numpy==1.22.4; python_version<='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy>=1.26.0,<1.27; python_version=='3.12'",
+    "numpy>=1.26.0,<1.27; python_version>='3.12'",
 ]
 
 


### PR DESCRIPTION
This fixes issue #30.
