### PR TITLE
Numpy 1.x backwards-compatibility fix

### DIFF
--- a/skmisc/loess/src/_loess.pyx
+++ b/skmisc/loess/src/_loess.pyx
@@ -680,7 +680,7 @@ cdef class loess_prediction:
         self.allocated = False
 
         # Note : we need a copy as we may have to normalize
-        p_ndr = np.asarray(newdata, copy=True, order='C')
+        p_ndr = np.array(newdata, copy=True, subok=True, order='C')
         p_ndr = p_ndr.astype(float)
 
         # Dimensions should match those of the input


### PR DESCRIPTION
Before Numpy 2.0, `numpy.asarray()` does not support a `copy` keyword.

Partially reverts (one line of) cd9026f90bd9e523fa9343d36968f0c0e4a7980f.

Fixes #35.