### PR TITLE
Update meson.build

### DIFF
--- a/skmisc/meson.build
+++ b/skmisc/meson.build
@@ -22,7 +22,7 @@ fortran_link_args = []
 
 if is_mingw
   is_mingw_built_python = run_command(
-    py, ['-c', 'import sysconfig; print(sysconfig.get_platform())'],
+    py3, ['-c', 'import sysconfig; print(sysconfig.get_platform())'],
     check: true).stdout().strip().startswith('mingw')
   if not is_mingw_built_python
     # For mingw-w64, link statically against the UCRT.


### PR DESCRIPTION
Use `py3` instead of `py` as command for checking `is_mingw_built_python`
It made no sense to use `py` solely here and it caused some errors when building in python 3.13 (but interestingly, no error was raised under python 3.12):

```
  × Failed to build `scikit-misc==0.5.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `mesonpy.build_wheel` failed (exit code: 1)

      [stdout]
      + meson setup C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src\.mesonpy-dtjfhhp9 -Dbuildtype=release
      -Db_ndebug=if-release -Db_vscrt=md --native-file=C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src\.mesonpy-dtjfhhp9\meson-python-native-file.ini
      The Meson build system
      Version: 1.7.0
      Source dir: C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src
      Build dir: C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src\.mesonpy-dtjfhhp9
      Build type: native build
      Project name: scikit-misc
      Project version: 0.5.1
      C compiler for the host machine: gcc (gcc 13.1.0 "gcc (x86_64-posix-seh-rev1, Built by MinGW-Builds project) 13.1.0")
      C linker for the host machine: gcc ld.bfd 2.39
      Cython compiler for the host machine: cython (cython 3.0.11)
      Host machine cpu family: x86_64
      Host machine cpu: x86_64
      Program python found: YES (C:\...\builds-v0\.tmps6Od9n\Scripts\python.exe)
      Run-time dependency python found: YES 3.13
      Program cython found: YES (C:\...\builds-v0\.tmps6Od9n\Scripts\cython.EXE)
      Compiler for C supports arguments -fno-strict-aliasing: YES
      Library m found: YES
      Fortran compiler for the host machine: gfortran (gcc 13.1.0 "GNU Fortran (x86_64-posix-seh-rev1, Built by MinGW-Builds project) 13.1.0")
      Fortran linker for the host machine: gfortran ld.bfd 2.39
      Compiler for Fortran supports arguments -Wno-conversion: YES
      Fetching value of define "__MINGW32__" : 1

      ..\skmisc\meson.build:25:4: ERROR: Unknown variable "py".

      A full log can be found at C:\...\pypi\scikit-misc\0.5.1\V_K_Fv2SvzlXysDrCwknj\src\.mesonpy-dtjfhhp9\meson-logs\meson-log.txt
```