### PR TITLE
Added Linux ARM wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -104,6 +104,7 @@ jobs:
         # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-24.04, manylinux_x86_64]
+        - [ubuntu-24.04-arm, manylinux_aarch64]
         - [macos-13, macosx_x86_64]
         - [macos-14, macosx_arm64]
         - [windows-2025, win_amd64]


### PR DESCRIPTION
scikit-misc is currently missing Linux ARM wheels. It's configured to be able to build them, but the Github workflow to actually execute that is missing.

To actually publish an ARM wheel, once this PR is merged:

1. Go to the Actions tab → Build Wheels workflow
2. Click Run workflow
3. In the branch/ref dropdown, select the v0.5.2 tag
4. Run it — this builds and publishes just the new aarch64 wheel via --skip-existing, leaving the rest of the v0.5.2 release untouched